### PR TITLE
Save answers in browser to recover on restart assessment

### DIFF
--- a/mock/db.json
+++ b/mock/db.json
@@ -8,7 +8,7 @@
       "description": "Matemática / Ciências / Geografia / Educação Física",
       "instructions": "1. Esta prova contém 25 (vinte e cinco) questões objetivas. <br/>2. Cada questão contém 4 (quatro) alternativas (A), (B), (C) e (D); apenas UMA ALTERNATIVA é a correta. Clique na opção que que você escolher como certa para registrar sua resposta.<br/>3. Leia com atenção antes de responder e selecione sua resposta após ler a questão. Procure não deixar questão sem resposta.<br/>4. Caso o texto ou a imagem estejam pequenos ou difíceis de ler, pressione as teclas \"ctrl\" e \"+\" para aumentar o zoom para aproximar. Caso queira reduzir o zoom, basta usar as teclas \"ctrl\" e \"-\".<br/>5. Você pode navegar entre as questões ao longo da prova, indo e voltando para qualquer uma delas. No entanto, depois de responder a última questão, a prova será entregue e você não poderá mais modificar as suas respostas.<br/>6. Não atualize e nem saia da página durante a realização da prova. Isso irá fazer com que o resultado seja perdido e sua nota desconsiderada. A prova só é considerada entregue quando a última questão for enviada.</br>7. A avaliação terá duração máxima de três (3) horas.",
       "duration": 120,
-      "numberOfItems": 60,
+      "numberOfItems": 3,
       "subjects": [
         "Matemática",
         "Ciências",

--- a/src/app/applyment/instructions-page/instructions-page.component.spec.ts
+++ b/src/app/applyment/instructions-page/instructions-page.component.spec.ts
@@ -88,7 +88,6 @@ describe('InstructionsPageComponent', () => {
     applymentService.setAssessment(ASSESSMENT);
     component.initAssessment();
 
-    expect(applyment.initAnswers).toHaveBeenCalledWith(ASSESSMENT.numberOfItems);
     expect(router.navigate).toHaveBeenCalledWith(['prova', ASSESSMENT.token, 'questao', '1']);
   }));
 

--- a/src/app/applyment/instructions-page/instructions-page.component.ts
+++ b/src/app/applyment/instructions-page/instructions-page.component.ts
@@ -45,8 +45,6 @@ export class InstructionsPageComponent extends HasModal implements OnInit {
     const assessmentToken = this._route.snapshot.params['token'];
     const studentToken = this._applymentService.getStudent().token;
 
-    this._applymentService.initAnswers(this.assessment.numberOfItems);
-
     this._assessmentService
       .fetchAssessmentQuestions(assessmentToken, studentToken)
       .subscribe(

--- a/src/app/applyment/question-page/question-page.component.spec.ts
+++ b/src/app/applyment/question-page/question-page.component.spec.ts
@@ -179,5 +179,12 @@ describe('QuestionPageComponent', () => {
         expect(router.navigate).toHaveBeenCalledWith(['prova', ASSESSMENT.token, 'questao', 2]);
       });
     });
+
+    it('should show amount of progression items', () => {
+      const progressionItemLength = fixture.debugElement.queryAll(By.css('.progression-path-item')).length;
+      const itemLength = applymentService.getItems().length;
+
+      expect(progressionItemLength).toEqual(itemLength);
+    });
   });
 });

--- a/src/app/applyment/question-page/question-page.component.spec.ts
+++ b/src/app/applyment/question-page/question-page.component.spec.ts
@@ -26,6 +26,7 @@ describe('QuestionPageComponent', () => {
   const QUESTIONS = [Mock.mockItem(), Mock.mockItem(1), Mock.mockItem(2)];
   const STUDENT = db.students[0];
   const ASSESSMENT = db.assessments[0];
+  const questionsLength = QUESTIONS.length;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -61,6 +62,10 @@ describe('QuestionPageComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('initAnswers', () => {
+    expect(ASSESSMENT.numberOfItems).toEqual(questionsLength);
   });
 
   it('should display a question', async(() => {

--- a/src/app/applyment/question-page/question-page.component.ts
+++ b/src/app/applyment/question-page/question-page.component.ts
@@ -44,6 +44,7 @@ export class QuestionPageComponent implements OnInit {
                         this.questionText = this.questionHTMLText();
                         this.options = this.question.answers;
                         document.body.scrollTop = 0;
+                        this._applymentService.initAnswers(this.questionsLength);
                     } catch (err) {
                         this.question = new Item();
                         this.options = [];

--- a/src/app/applyment/review-page/review-page.component.ts
+++ b/src/app/applyment/review-page/review-page.component.ts
@@ -88,7 +88,10 @@ export class ReviewPageComponent extends HasModal implements OnInit {
           this.closeModal();
         },
         onDownload: (code) => {
-          this._assessmentService.downloadBackup(code);
+          Promise.all([
+            this._assessmentService.downloadBackup(code),
+            window.localStorage.clear()
+          ])
         }
       });
     }, 300);
@@ -119,6 +122,7 @@ export class ReviewPageComponent extends HasModal implements OnInit {
         .subscribe(
           () => {
             this._router.navigate(['prova', this.assessment.token, 'parabens']);
+            window.localStorage.clear();
           },
           this.openErrorModal.bind(this)
         );
@@ -126,7 +130,6 @@ export class ReviewPageComponent extends HasModal implements OnInit {
 
   deliver() {
     this.modalRef.instance.isSubmitting = true;
-    this.writeBackup();
 
     this._connection
         .getStatusOnce()
@@ -137,13 +140,6 @@ export class ReviewPageComponent extends HasModal implements OnInit {
             this.openNoConnectionModal();
           }
         });
-  }
-
-  writeBackup() {
-    const answers = this._applymentService.getAllAnswers().filter(answer => answer);
-    window.localStorage.setItem('studentToken', this.student.token);
-    window.localStorage.setItem('assessmentToken', this.assessment.token);
-    window.localStorage.setItem('answers-' + this.student.token, btoa(JSON.stringify(answers)));
   }
 
   setNotAnswered(allAnswers: Answer[]) {

--- a/src/app/applyment/shared/applyment.service.ts
+++ b/src/app/applyment/shared/applyment.service.ts
@@ -64,12 +64,20 @@ export class ApplymentService {
   setAnswer(itemIndex: number, answer: Answer) {
     const answers = this._store.state.applyment.answers;
     answers[itemIndex] = answer;
+    window.localStorage.setItem(`answers-${this._store.state.applyment.student.token}`, window.btoa(JSON.stringify(answers)));
 
     const newState = _.merge({}, this._store.state, { applyment: { answers } });
     this._store.setState(newState);
   }
 
   getAnswer(itemIndex: number): Answer {
+    const storage = window.localStorage.getItem(`answers-${this._store.state.applyment.student.token}`);
+    if (!!storage) {
+      const answers = JSON.parse(atob(storage));
+      const newState = _.merge({}, this._store.state, { applyment: { answers } });
+      this._store.setState(newState);
+    }
+
     return this._store.state.applyment.answers[itemIndex] || null;
   }
 

--- a/src/app/core/shared/assessment.service.spec.ts
+++ b/src/app/core/shared/assessment.service.spec.ts
@@ -193,13 +193,19 @@ describe('AssessmentService', () => {
   describe('downloadBackup()', () => {
     it('should return base64 string with student answers',
       inject([AssessmentService], (service: AssessmentService) => {
-        window.localStorage.setItem('answers-PXK-9997', 'W3sib3B0aW9uSWQiOjMsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZCJ9LHsib3B0aW9uSWQiOjQsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZSJ9LHsib3B0aW9uSWQiOjIsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZiJ9LHsib3B0aW9uSWQiOjQsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE4MCJ9XQ==');
-        window.localStorage.setItem('assessmentToken', 'caieiras8240a');
-        window.localStorage.setItem('studentToken', 'PXK-9997');
+        window.localStorage.clear();
+        window.localStorage.setItem('answers-PXK-9997', 'W3sib3B0aW9uSWQiOjMsIml0ZW1JZCI6IjU4ZWQzMGEx' +
+          'OTk3ZTIxMGFjYTA5MDE3ZCJ9LHsib3B0aW9uSWQiOjQsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZS' +
+          'J9LHsib3B0aW9uSWQiOjIsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZiJ9LHsib3B0aW9uSWQiOjQs' +
+          'Iml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE4MCJ9XQ==');
 
         const content = service.downloadBackup('offjkl9');
 
-        expect(content).toEqual('data:text/plain;charset=utf-8,' + encodeURIComponent('{"answers-PXK-9997":"W3sib3B0aW9uSWQiOjMsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZCJ9LHsib3B0aW9uSWQiOjQsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZSJ9LHsib3B0aW9uSWQiOjIsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZiJ9LHsib3B0aW9uSWQiOjQsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE4MCJ9XQ==","assessmentToken":"caieiras8240a","studentToken":"PXK-9997"}'));
+        expect(content).toEqual('data:text/plain;charset=utf-8,' +
+          encodeURIComponent('{"answers-PXK-9997":"W3sib3B0aW9uSWQiOjMsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZT' +
+          'IxMGFjYTA5MDE3ZCJ9LHsib3B0aW9uSWQiOjQsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZSJ9LHsi' +
+          'b3B0aW9uSWQiOjIsIml0ZW1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE3ZiJ9LHsib3B0aW9uSWQiOjQsIml0ZW' +
+          '1JZCI6IjU4ZWQzMGExOTk3ZTIxMGFjYTA5MDE4MCJ9XQ=="}'));
       })
     );
   });


### PR DESCRIPTION
This PR closes issue [QP-339](https://portalqedu.atlassian.net/browse/QP-339).
 
## Main changes
 
- Added web storage support to save answers in browser
- Improves backup removing the storage after sending the results or download
- Updating backup test for current behavior
- Amount navigation items in assessment page fixed
